### PR TITLE
Removed regex check from api routes

### DIFF
--- a/src/routes/v1/settings/index.ts
+++ b/src/routes/v1/settings/index.ts
@@ -3,13 +3,13 @@ import express from 'express'
 const router = express.Router()
 
 
-router.post('/:guild_id(\\d{18})', (req, res) => {
+router.post('/:guild_id', (req, res) => {
     return res.json({})
 })
-router.get('/:guild_id(\\d{18})', (req, res) => {
+router.get('/:guild_id', (req, res) => {
     return res.json({})
 })
-router.patch('/:guild_id(\\d{18})', (req, res) => {
+router.patch('/:guild_id', (req, res) => {
     return res.json({})
 })
 

--- a/src/routes/v1/warnings/index.ts
+++ b/src/routes/v1/warnings/index.ts
@@ -2,10 +2,10 @@ import express from 'express'
 
 const router = express.Router()
 
-router.get('/:guild_id(\\d{18})', (req, res) => {
+router.get('/:guild_id', (req, res) => {
     return res.json({})
 })
-router.get('/:guild_id(\\d{18})/:user_id(\\d{18})', (req, res) => {
+router.get('/:guild_id/:user_id', (req, res) => {
     return res.json({});
 })
 

--- a/src/routes/v1/xp/index.ts
+++ b/src/routes/v1/xp/index.ts
@@ -2,10 +2,10 @@ import express from 'express'
 
 const router = express.Router()
 
-router.get('/:guild_id(\\d{18})', (req, res) => {
+router.get('/:guild_id', (req, res) => {
     return res.json({})
 })
-router.get('/:guild_id(\\d{18})/:user_id(\\d{18})', (req, res) => {
+router.get('/:guild_id/:user_id', (req, res) => {
     return res.json({});
 })
 


### PR DESCRIPTION
Routes now don't have regex checks at the server level. They should be handled by the inner implementation.