### PR TITLE
Fixed test time check

### DIFF
--- a/tests/http/v1/warnings/warnings.test.ts
+++ b/tests/http/v1/warnings/warnings.test.ts
@@ -13,10 +13,11 @@ afterAll(() => DB.close());
 
 describe('Create Warning (User)', () => {
   test('Valid', async () => {
-    // Get time now to compare later
-    const timeNow = Date.now();
     // Create a valid user
     await expect(DB.execute('INSERT INTO UserInGuilds (UserID, GuildID) VALUES (?, ?)', [1, 1])).resolves.not.toThrow();
+
+    // Get request time now to compare later
+    const timeNow = Date.now();
     const request = http('POST', `${ROUTE}/1/1`, { reason: 'Test Reason', adminID: 2 });
     expect(request.statusCode).toStrictEqual(200);
     const response = JSON.parse(String(request.getBody() as string));


### PR DESCRIPTION
Moved the request start reference time in the test file as the pipeline would take too long and the realistic completion time takes longer than a second.

Despite the main pipeline passing at the moment, this should be implemented to reduce the chances of the pipeline failing in the future