### PR TITLE
Fix createWarning()

### DIFF
--- a/docs/api.yml
+++ b/docs/api.yml
@@ -470,8 +470,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/UserWarning"
-        "404":
-          description: Guild/User ID not found
     get:
       tags:
         - User Warnings

--- a/tests/implementation/warnings/warnings.test.ts
+++ b/tests/implementation/warnings/warnings.test.ts
@@ -13,15 +13,12 @@ afterAll(() => DB.close());
 
 describe('Create Warning', () => {
   test('Valid', async () => {
-    await expect(DB.execute('INSERT INTO UserInGuilds (UserID, GuildID) VALUES (?, ?)', [1, 1])).resolves.not.toThrow();
     await expect(createWarning(1, 1, 'Test Reason', 2)).resolves.not.toThrow();
   });
   test('Invalid (Reason empty)', async () => {
-    await expect(DB.execute('INSERT INTO UserInGuilds (UserID, GuildID) VALUES (?, ?)', [1, 1])).resolves.not.toThrow();
     await expect(createWarning(1, 1, '', 2)).rejects.toThrow();
   });
   test('Invalid (AdminID empty)', async () => {
-    await expect(DB.execute('INSERT INTO UserInGuilds (UserID, GuildID) VALUES (?, ?)', [1, 1])).resolves.not.toThrow();
     await expect(createWarning(1, 1, 'Test Reason', null)).rejects.toThrow();
   });
 });


### PR DESCRIPTION
- Modified `createWarning()` to create a user object if not present already, eliminating the need for a 404 error
- 404 error removed from `POST /warnings/guild_id/user_id` route in API spec

Closes #57 