### PR TITLE
Fix setSettings() setting empty object

### DIFF
--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -43,10 +43,12 @@ export async function getSettings(guildID: bigint | number): Promise<any> {
 }
 
 /**
- *
+ * Sets the settings for a guild ID given an object with the complete new settings
  * @param {bigint | number} guildID The guild ID to update
  * @param {object} settings The new settings to override
- * @returns
+ * @throws {createErrors<400>} when settings are empty
+ * @throws {createErrors<404>} when guild does not exist
+ * @returns {object} the new settings
 */
 export async function setSettings(guildID: bigint | number, settings: object): Promise<any> {
   if (Object.keys(settings).length === 0) {

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -49,6 +49,9 @@ export async function getSettings(guildID: bigint | number): Promise<any> {
  * @returns
 */
 export async function setSettings(guildID: bigint | number, settings: object): Promise<any> {
+  if (Object.keys(settings).length === 0) {
+    throw createErrors(400, 'Settings can not be empty');
+  }
   if (Object.keys(await DB.record('SELECT * FROM GuildSettings WHERE GuildID = ?', [guildID])).length === 0) {
     throw createErrors(404, 'This guild does not exist.');
   }

--- a/tests/http/v1/settings/settings.test.ts
+++ b/tests/http/v1/settings/settings.test.ts
@@ -57,8 +57,13 @@ describe('PUT', () => {
     expect(REQ.statusCode).toStrictEqual(200);
     expect(JSON.parse(REQ.getBody() as string)).toStrictEqual({ setting1: false });
   });
+  test('Invalid (Settings empty)', () => {
+    // Create an entry
+    expect(http('POST', `${ROUTE}/1`, { setting1: true }).statusCode).toStrictEqual(200);
+    expect(http('PUT', `${ROUTE}/1`, {}).statusCode).toStrictEqual(400);
+  });
   test('Invalid (Guild does not exist)', () => {
-    expect(http('PUT', `${ROUTE}/1`, {}).statusCode).toStrictEqual(404);
+    expect(http('PUT', `${ROUTE}/1`, { setting1: true }).statusCode).toStrictEqual(404);
   });
 });
 

--- a/tests/implementation/settings/settings.test.ts
+++ b/tests/implementation/settings/settings.test.ts
@@ -47,6 +47,10 @@ describe('Set settings', () => {
   test('Guild ID does not exist', async () => {
     await expect(setSettings(1, { setting1: false })).rejects.toThrow();
   });
+  test('Empty settings', async () => {
+    await expect(createSettings(1, { setting1: true, setting2: false, setting3: {} })).resolves.not.toThrow();
+    await expect(setSettings(1, {})).rejects.toThrow();
+  });
 });
 
 describe('Update settings', () => {


### PR DESCRIPTION
Modifed tests and implementation of `setSettings()` to throw a 400 when empty settings are provided

Closes #61 