### PR TITLE
updated types and postUserXP

### DIFF
--- a/docs/api.yml
+++ b/docs/api.yml
@@ -623,6 +623,6 @@ components:
       type: object
       example:
         XP: 100
-        VC_XPLock: 16717274013
+        VoiceChannelXPLock: 16717274013
 security:
   - APIKey: []

--- a/src/routes/v1/xp/index.ts
+++ b/src/routes/v1/xp/index.ts
@@ -29,7 +29,7 @@ router.get(
 router.post(
   '/:guild_id/:user_id',
   asyncHandler(async (req: Request, res: Response) => {
-    res.json(await postUserXP(BigInt(req.params.guild_id), BigInt(req.params.user_id)));
+    res.json(await postUserXP(BigInt(req.params.guild_id), BigInt(req.params.user_id), req.body));
   })
 );
 

--- a/tests/http/v1/xp/xp.test.ts
+++ b/tests/http/v1/xp/xp.test.ts
@@ -69,6 +69,11 @@ describe('Post User XP Data', () => {
     // should fail when called again on same user in same guild
     expect(http('POST', `${ROUTE}/1/1`).statusCode).toStrictEqual(409);
   });
+
+  test('Testing optional parameters passed in', async () => {
+    expect(http('POST', `${ROUTE}/1/1`, { XP: 333, Level: 11 }).statusCode).toStrictEqual(200);
+    expect(http('GET', `${ROUTE}/1/1`).statusCode).toStrictEqual(200);
+  });
 });
 
 describe('Update User XP Data', () => {

--- a/tests/implementation/xp/xp.test.ts
+++ b/tests/implementation/xp/xp.test.ts
@@ -57,6 +57,12 @@ describe('Posting User XP data', () => {
     // should fail when trying to add same user in same guild again
     await expect(postUserXP(1, 1)).rejects.toThrow();
   });
+  test('Testing optional parameters past in', async () => {
+    const time = Math.floor(Date.now() / 1000);
+    await expect(postUserXP(1, 1, { XP: 1, Level: 1, XPLock: time, VoiceChannelXPLock: time })).resolves.not.toThrow();
+    // expect any number for userGuildID due to auto-increment
+    expect(await fetchUserXP(1, 1)).toMatchObject({ UserGuildID: expect.any(Number), XP: 1, Level: 1, XPLock: time, VoiceChannelXPLock: time });
+  });
 });
 
 describe('Updating User XP data', () => {


### PR DESCRIPTION
- Implemented return types for routes in XP
- Updated `postUserXP` to take in an optional object to set new XP
- Added new tests for ^
- Updated `postUserXP` to insert using epoch seconds

Closes #54 
Closes #15 