### PR TITLE
warnings/deleteGuildWarnings

### DIFF
--- a/src/routes/v1/warnings/index.ts
+++ b/src/routes/v1/warnings/index.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import asyncHandler from 'express-async-handler';
-import { createWarning, deleteWarning, getUserWarnings } from '@src/warnings';
+import { createWarning, deleteGuildWarnings, deleteWarning, getUserWarnings } from '@src/warnings';
 import { Request, Response } from 'express';
 
 const router = express.Router();
@@ -13,6 +13,9 @@ router.post('/:guild_id/:user_id', asyncHandler(async (req: Request, res: Respon
 }));
 router.get('/:guild_id/:user_id', asyncHandler(async (req: Request, res: Response) => {
   res.json(await getUserWarnings(BigInt(req.params.user_id), BigInt(req.params.guild_id)));
+}));
+router.delete('/:guild_id(\\d+)', asyncHandler(async (req: Request, res: Response) => {
+  res.json(await deleteGuildWarnings(BigInt(req.params.guild_id)));
 }));
 router.delete('/:warning_id', asyncHandler(async (req: Request, res: Response) => {
   res.json(await deleteWarning(req.params.warning_id));

--- a/src/warnings/index.ts
+++ b/src/warnings/index.ts
@@ -61,3 +61,16 @@ export async function deleteWarning(warningID: string): Promise<Record<string, n
   await DB.execute('DELETE FROM Warnings WHERE WarningID = ?', [warningID]);
   return {};
 }
+
+/**
+ * Removes all warnings for a given guild
+ * @param {bigint | number} guildID The guild ID to delete warnings from
+ * @throws {createErrors<404>} Guild ID not found
+ * @returns {}
+ */
+export async function deleteGuildWarnings(guildID: bigint | number): Promise<Record<string, never>> {
+  const result: Warning[] = await DB.records('SELECT w.WarningID, w.UserGuildID, w.Reason, UNIX_TIMESTAMP(w.Time) AS Time, w.AdminID FROM Warnings AS w INNER JOIN UserInGuilds u ON w.UserGuildID = u.UserGuildID WHERE u.GuildID = ?', [guildID]);
+  if (result.length === 0) throw createErrors(404, 'Guild ID not found in database');
+  await DB.execute("DELETE w FROM Warnings AS w INNER JOIN UserInGuilds u ON w.UserGuildID = u.UserGuildID WHERE u.GuildID = ?', [guildID]");
+  return {};
+}

--- a/src/warnings/index.ts
+++ b/src/warnings/index.ts
@@ -69,7 +69,7 @@ export async function deleteWarning(warningID: string): Promise<Record<string, n
  * @returns {}
  */
 export async function deleteGuildWarnings(guildID: bigint | number): Promise<Record<string, never>> {
-  const result: Warning[] = await DB.records('SELECT w.WarningID, w.UserGuildID, w.Reason, UNIX_TIMESTAMP(w.Time) AS Time, w.AdminID FROM Warnings AS w INNER JOIN UserInGuilds u ON w.UserGuildID = u.UserGuildID WHERE u.GuildID = ?', [guildID]);
+  const result: string[] = await DB.column('SELECT w.WarningID FROM Warnings AS w INNER JOIN UserInGuilds u ON w.UserGuildID = u.UserGuildID WHERE u.GuildID = ?', [guildID]);
   if (result.length === 0) throw createErrors(404, 'Guild ID not found in database');
   await DB.execute('DELETE w FROM Warnings AS w INNER JOIN UserInGuilds u ON w.UserGuildID = u.UserGuildID WHERE u.GuildID = ?', [guildID]);
   return {};

--- a/src/warnings/index.ts
+++ b/src/warnings/index.ts
@@ -71,6 +71,6 @@ export async function deleteWarning(warningID: string): Promise<Record<string, n
 export async function deleteGuildWarnings(guildID: bigint | number): Promise<Record<string, never>> {
   const result: Warning[] = await DB.records('SELECT w.WarningID, w.UserGuildID, w.Reason, UNIX_TIMESTAMP(w.Time) AS Time, w.AdminID FROM Warnings AS w INNER JOIN UserInGuilds u ON w.UserGuildID = u.UserGuildID WHERE u.GuildID = ?', [guildID]);
   if (result.length === 0) throw createErrors(404, 'Guild ID not found in database');
-  await DB.execute("DELETE w FROM Warnings AS w INNER JOIN UserInGuilds u ON w.UserGuildID = u.UserGuildID WHERE u.GuildID = ?', [guildID]");
+  await DB.execute('DELETE w FROM Warnings AS w INNER JOIN UserInGuilds u ON w.UserGuildID = u.UserGuildID WHERE u.GuildID = ?', [guildID]);
   return {};
 }

--- a/tests/http/v1/warnings/warnings.test.ts
+++ b/tests/http/v1/warnings/warnings.test.ts
@@ -102,3 +102,15 @@ describe('Delete warning', () => {
     expect(http('DELETE', `${ROUTE}/abcde`).statusCode).toStrictEqual(404);
   });
 });
+
+describe('Delete guild warnings', () => {
+  test('Valid', async () => {
+    expect(http('POST', `${ROUTE}/2/1`, { reason: 'Test Reason', adminID: 2 }).statusCode).toStrictEqual(200);
+    const req = http('DELETE', `${ROUTE}/2`);
+    expect(req.statusCode).toStrictEqual(200);
+    expect(JSON.parse(req.getBody() as string)).toStrictEqual({});
+  });
+  test('Invalid (Warning ID does not exist)', async () => {
+    expect(http('DELETE', `${ROUTE}/2`).statusCode).toStrictEqual(404);
+  });
+});

--- a/tests/http/v1/warnings/warnings.test.ts
+++ b/tests/http/v1/warnings/warnings.test.ts
@@ -99,6 +99,6 @@ describe('Delete warning', () => {
     expect(http('DELETE', `${ROUTE}/${warningID}`).statusCode).toStrictEqual(200);
   });
   test('Invalid (Warning ID does not exist)', async () => {
-    expect(http('POST', `${ROUTE}/abcde`).statusCode).toStrictEqual(404);
+    expect(http('DELETE', `${ROUTE}/abcde`).statusCode).toStrictEqual(404);
   });
 });

--- a/tests/implementation/warnings/warnings.test.ts
+++ b/tests/implementation/warnings/warnings.test.ts
@@ -1,5 +1,5 @@
 import DB from '@utils/DBHandler';
-import { createWarning, deleteWarning, getUserWarnings } from '@src/warnings';
+import { createWarning, deleteGuildWarnings, deleteWarning, getUserWarnings } from '@src/warnings';
 
 // Ensure DB is in a predictable state by clearing it initially, then again after every test
 // We then close the DB at the end to remove any open handles
@@ -69,5 +69,15 @@ describe('Delete Warnings', () => {
   });
   test('Invalid (Warning ID does not exist)', async () => {
     await expect(deleteWarning('abcde')).rejects.toThrow();
+  });
+});
+describe('Delete Guild Warnings', () => {
+  test('Valid', async () => {
+    await createWarning(1, 2, 'boring reason', 1);
+    await createWarning(1, 2, 'another boring reason', 1);
+    await expect(deleteGuildWarnings(2)).resolves.not.toThrow();
+  });
+  test('Invalid (Guild ID does not exist)', async () => {
+    await expect(deleteGuildWarnings(2)).rejects.toThrow();
   });
 });

--- a/tests/implementation/warnings/warnings.test.ts
+++ b/tests/implementation/warnings/warnings.test.ts
@@ -76,6 +76,7 @@ describe('Delete Guild Warnings', () => {
     await createWarning(1, 2, 'boring reason', 1);
     await createWarning(1, 2, 'another boring reason', 1);
     await expect(deleteGuildWarnings(2)).resolves.not.toThrow();
+    await expect(getGuildWarnings(2)).rejects.toThrow();
   });
   test('Invalid (Guild ID does not exist)', async () => {
     await expect(deleteGuildWarnings(2)).rejects.toThrow();


### PR DESCRIPTION
- Added tests and implementation for `DELETE /warnings/guild_id`
- Also fixed a typo in a previous warnings test which was calling `POST` instead of `DELETE`

Closes #29 