### PR TITLE
returnTypeFix + other changes

### DIFF
--- a/docs/api.yml
+++ b/docs/api.yml
@@ -551,11 +551,11 @@ components:
         UserID:
           type: string
           description: The user ID
-          example: "1"
+          example: "1n"
         GuildID:
           type: string
           description: The guild ID of the user 
-          example: "1"
+          example: "1n"
         XP:
           type: integer
           description: The current XP value
@@ -606,10 +606,14 @@ components:
           type: string
           format: uuid
           description: The Warning ID
-        UserGuildID:
-          type: integer
-          description: The UserGuildID
-          example: 231
+        UserID:
+          type: string
+          description: The User ID of the warning 
+          example: "1n"
+        GuildID:
+          type: string 
+          description: The Guild ID where the warning was issued 
+          example: "1n"
         Reason:
           type: string
           description: The reason behind the warning

--- a/docs/api.yml
+++ b/docs/api.yml
@@ -548,10 +548,14 @@ components:
     UserXP:
       type: object
       properties:
-        UserGuildID:
-          type: integer
-          description: The UserGuildID
-          example: 1
+        UserID:
+          type: string
+          description: The user ID
+          example: "1"
+        GuildID:
+          type: string
+          description: The guild ID of the user 
+          example: "1"
         XP:
           type: integer
           description: The current XP value

--- a/src/interfaces/settings.ts
+++ b/src/interfaces/settings.ts
@@ -1,8 +1,3 @@
 export interface Settings {
   [Setting: string]: boolean | string | number | object;
 }
-
-export interface SettingsReturn {
-  GuildID: number;
-  SettingsData: Settings;
-}

--- a/src/interfaces/warnings.ts
+++ b/src/interfaces/warnings.ts
@@ -1,7 +1,8 @@
 export interface Warning {
-    WarningID: string,
-    UserGuildID: number,
-    Reason: string,
-    Time: number,
-    AdminID: bigint | number
+  WarningID: string;
+  UserID: bigint | number;
+  GuildID: bigint | number;
+  Reason: string;
+  Time: number;
+  AdminID: bigint | number;
 }

--- a/src/interfaces/xp.ts
+++ b/src/interfaces/xp.ts
@@ -1,22 +1,4 @@
 export interface UserXP {
-  UserID: number;
-  GuildID: number;
-  XP: number;
-  Level: number;
-  XPLock: number;
-  VoiceChannelXPLock: number;
-}
-
-export interface UserXPReturn {
-  UserID: string;
-  GuildID: string;
-  XP: number;
-  Level: number;
-  XPLock: number;
-  VoiceChannelXPLock: number;
-}
-
-export interface UserXPInternal {
   UserGuildID: number;
   XP: number;
   Level: number;
@@ -25,6 +7,7 @@ export interface UserXPInternal {
 }
 
 export interface CreateUserXPInput {
+  UserGuildID?: number;
   XP?: number;
   Level?: number;
   XPLock?: number;

--- a/src/interfaces/xp.ts
+++ b/src/interfaces/xp.ts
@@ -1,5 +1,6 @@
 export interface UserXP {
-  UserGuildID: number;
+  UserID: bigint | number;
+  GuildID: bigint | number;
   XP: number;
   Level: number;
   XPLock: number;
@@ -7,7 +8,6 @@ export interface UserXP {
 }
 
 export interface CreateUserXPInput {
-  UserGuildID?: number;
   XP?: number;
   Level?: number;
   XPLock?: number;

--- a/src/interfaces/xp.ts
+++ b/src/interfaces/xp.ts
@@ -1,4 +1,22 @@
 export interface UserXP {
+  UserID: number;
+  GuildID: number;
+  XP: number;
+  Level: number;
+  XPLock: number;
+  VoiceChannelXPLock: number;
+}
+
+export interface UserXPReturn {
+  UserID: string;
+  GuildID: string;
+  XP: number;
+  Level: number;
+  XPLock: number;
+  VoiceChannelXPLock: number;
+}
+
+export interface UserXPInternal {
   UserGuildID: number;
   XP: number;
   Level: number;
@@ -7,7 +25,6 @@ export interface UserXP {
 }
 
 export interface CreateUserXPInput {
-  UserGuildID?: number;
   XP?: number;
   Level?: number;
   XPLock?: number;

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,6 +16,7 @@ const app = express();
 app.use(express.json());
 app.use(cors());
 app.set('trust proxy', true);
+app.set('json replacer', (_: any, value: any) => (typeof value === 'bigint' ? value.toString() + 'n' : value));
 app.use(morgan(process.env.NODE_ENV !== 'production' ? 'dev' : 'common'));
 
 // Public Routes
@@ -26,10 +27,12 @@ app.get('/', (req: Request, res: Response) => {
 app.use('/docs', swaggerUi.serve, swaggerUi.setup(YAML.load('docs/api.yml')));
 
 // All routes below this are authenticated
-app.use(asyncHandler(async (req: Request, res: Response, next: NextFunction) => {
-  await validateSession(req.headers['x-api-key'] as string);
-  next();
-}));
+app.use(
+  asyncHandler(async (req: Request, res: Response, next: NextFunction) => {
+    await validateSession(req.headers['x-api-key'] as string);
+    next();
+  })
+);
 
 // Protected Routes
 

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -6,11 +6,11 @@ import lodash from 'lodash';
 /**
  * Stores settings for a given guild ID into the database
  *
- * @param {bigint | number} guildID The guild ID to create settings for
- * @param {object} settings an object with key:value pairs of settings for this guild
- * @throws {createErrors<400>} if settings not provided
- * @throws {createErrors<409>} if settings already exist
- * @returns {object} Empty object
+ * @param {bigint | number} guildID - the guildID to create settings for
+ * @param {Settings} settings - an object with key:value pairs of settings for this guild
+ * @throws {createErrors<400>} - if settings not provided
+ * @throws {createErrors<409>} - if settings already exist
+ * @returns {Promise<Settings>}
  */
 export async function createSettings(guildID: bigint | number, settings: Settings): Promise<Settings> {
   if (Object.keys(settings).length === 0) {
@@ -30,9 +30,10 @@ export async function createSettings(guildID: bigint | number, settings: Setting
 
 /**
  * Fetches settings for the given guild
- * @param guildID The guild ID to fetch
- * @throws {createErrors<404>} if not found
- * @returns {object}
+ *
+ * @param {bigint | number} guildID - the guildID to fetch settings data for
+ * @throws {createErrors<404>} - if settings for that guildID are not found
+ * @returns {Promise<Settings>}
  */
 export async function getSettings(guildID: bigint | number): Promise<Settings> {
   const res: Settings = await DB.field('SELECT SettingsData FROM GuildSettings WHERE GuildID = ?', [guildID]);
@@ -44,11 +45,12 @@ export async function getSettings(guildID: bigint | number): Promise<Settings> {
 
 /**
  * Sets the settings for a guild ID given an object with the complete new settings
- * @param {bigint | number} guildID The guild ID to update
- * @param {object} settings The new settings to override
- * @throws {createErrors<400>} when settings are empty
- * @throws {createErrors<404>} when guild does not exist
- * @returns {object} the new settings
+ *
+ * @param {bigint | number} guildID - the guildID to update settings data for
+ * @param {Settings} settings - the new settings to override
+ * @throws {createErrors<400>} - when settings are empty
+ * @throws {createErrors<404>} - when no settings are found for the given guildID
+ * @returns {Promise<Settings>}
  */
 export async function setSettings(guildID: bigint | number, settings: Settings): Promise<Settings> {
   if (Object.keys(settings).length === 0) {
@@ -61,11 +63,12 @@ export async function setSettings(guildID: bigint | number, settings: Settings):
 
 /**
  * Updates the settings for a guild ID given an object with only the new changes to be made
- * @param guildID the guild ID to update
- * @param {object} newSettings an object with the settings to update
- * @throws {createErrors<400>} if no new settings are provided
- * @throws {createErrors<404>} if the guild ID does not exist
- * @returns {object} empty object on success
+ *
+ * @param {bigint | number} guildID - the guildID to update settings data for
+ * @param {Settings} newSettings - an object with the settings to update
+ * @throws {createErrors<400>} - if no new settings are provided
+ * @throws {createErrors<404>} - when no settings are found for the given guildID
+ * @returns {Promise<Settings>}
  */
 export async function updateSettings(guildID: bigint | number, newSettings: Settings): Promise<Settings> {
   if (Object.keys(newSettings).length === 0) {
@@ -79,8 +82,9 @@ export async function updateSettings(guildID: bigint | number, newSettings: Sett
 
 /**
  * Removes settings for a given guild
- * @param {bigint | number} guildID The guild ID to delete
- * @throws {createErrors<404>} if guild ID not found
+ *
+ * @param {bigint | number} guildID - the guildID to delete settings data for
+ * @throws {createErrors<404>} - if no settings data found for the given guildID
  * @returns {}
  */
 export async function deleteSettings(guildID: bigint | number): Promise<Record<string, never>> {

--- a/src/verification/index.ts
+++ b/src/verification/index.ts
@@ -6,11 +6,12 @@ import lodash from 'lodash';
 
 /**
  * Adds a user from a given guild into verification. Putting this user into lock down immediately is possible
- * @param {bigint | number} userID - The User ID to add to verification
- * @param {bigint | number} guildID - The guild ID the user belongs to
- * @param {bigint | number | undefined} messageID - Optional ID of the lock down approval message
- * @param {bigint | number | undefined} channelID - Optional ID of the lock down approval channel
- * @throws {createErrors<409>} - User already in verification
+ *
+ * @param {bigint | number} userID - the userID to add to verification
+ * @param {bigint | number} guildID - the guildID the user belongs to
+ * @param {bigint | number | undefined} messageID - optional ID of the lock down approval message
+ * @param {bigint | number | undefined} channelID - optional ID of the lock down approval channel
+ * @throws {createErrors<409>} - user already in verification
  * @returns {Promise<Verification>}
  */
 export async function addVerification(userID: bigint | number, guildID: bigint | number, messageID?: bigint | number, channelID?: bigint | number): Promise<Verification> {
@@ -28,15 +29,16 @@ export async function addVerification(userID: bigint | number, guildID: bigint |
   return {
     UserID: userID,
     GuildID: guildID,
-    JoinTime: TIME
+    JoinTime: TIME,
   };
 }
 
 /**
  * Remove a user from verification
- * @param {bigint | number} userID - The User ID to add to verification
- * @param {bigint | number} guildID - The guild ID the user belongs to
- * @throws {createErrors<404>} - Guild/User ID not found
+ *
+ * @param {bigint | number} userID - the userID to add to verification
+ * @param {bigint | number} guildID - the guildID the user belongs to
+ * @throws {createErrors<404>} - guildID/userID not found in the database
  * @returns {}
  */
 export async function removeVerification(userID: bigint | number, guildID: bigint | number): Promise<Record<string, never>> {
@@ -47,11 +49,12 @@ export async function removeVerification(userID: bigint | number, guildID: bigin
 
 /**
  * Adds a user from a given guild into verification. Putting this user into lock down immediately is possible
- * @param {bigint | number} userID - The User ID to add to verification
- * @param {bigint | number} guildID - The guild ID the user belongs to
+ *
+ * @param {bigint | number} userID - the UserID to add to verification
+ * @param {bigint | number} guildID - the guildID the user belongs to
  * @param {LockdownInput} data - the new lock down data to add to the user
  * @throws {createErrors<400>} - if provided lock down data is not complete or data is empty
- * @throws {createErrors<404>} - User/Guild ID not found
+ * @throws {createErrors<404>} - userID/guildID not found in the database
  * @returns {Promise<Verification>}
  */
 export async function updateVerification(userID: bigint | number, guildID: bigint | number, data: LockdownInput): Promise<Verification> {

--- a/src/warnings/index.ts
+++ b/src/warnings/index.ts
@@ -4,16 +4,17 @@ import { v4 as uuidv4 } from 'uuid';
 import { Warning } from '@interfaces/warnings';
 import { createUserGuildID } from '@utils/Misc';
 
-const queryValues = 'WarningID, UserGuildID, Reason, Time, AdminID';
+const queryValues = 'WarningID, UserID, GuildID, Reason, Time, AdminID';
 
 /**
  * Creates a warning for a given user within a particular guild
- * @param {bigint | number} userID The user ID to create a warning for
- * @param {bigint | number} guildID The guild ID the user belongs to
- * @param {string} reason The reason for the warning
- * @param {bigint | number} adminID The adminID who distributed the warning
- * @throws {createErrors<400>} Reason/AdminID is left empty
- * @returns {object} the warning created
+ *
+ * @param {bigint | number} userID - the userID to create a warning for
+ * @param {bigint | number} guildID - the guildID the user belongs to
+ * @param {string} reason - the reason for the warning
+ * @param {bigint | number} adminID - the adminID who distributed the warning
+ * @throws {createErrors<400>} - reason/adminID is left empty
+ * @returns {Promise<Warning>}
  */
 export async function createWarning(userID: bigint | number, guildID: bigint | number, reason: string, adminID: bigint | number): Promise<Warning> {
   if (reason === undefined || reason === '') {
@@ -25,21 +26,23 @@ export async function createWarning(userID: bigint | number, guildID: bigint | n
   const userGuildID: number = await createUserGuildID(guildID, userID);
   const RESULT: Warning = {
     WarningID: uuidv4(),
-    UserGuildID: userGuildID,
+    UserID: userID,
+    GuildID: guildID,
     Reason: reason,
     Time: Math.floor(Date.now() / 1000),
     AdminID: adminID,
   };
-  await DB.execute(`INSERT INTO Warnings (${queryValues}) VALUES (?, ?, ?, FROM_UNIXTIME(?), ?)`, Object.values(RESULT));
+  await DB.execute('INSERT INTO Warnings (WarningID, UserGuildID, Reason, Time, AdminID) VALUES (?, ?, ?, FROM_UNIXTIME(?), ?)', [RESULT.WarningID, userGuildID, RESULT.Reason, RESULT.Time, RESULT.AdminID]);
   return RESULT;
 }
 
 /**
  * Fetches all user warnings from a given guild
- * @param {bigint | number} userID the user ID to fetch warnings for
- * @param {bigint |number} guildID the guild ID the user belongs to
- * @throws {createErrors<404>} if User/Guild ID not found
- * @returns {Array} of warnings belonging to that user
+ *
+ * @param {bigint | number} userID - the userID to fetch warnings for
+ * @param {bigint |number} guildID - the guildID the user belongs to
+ * @throws {createErrors<404>} - if userID/guildID not found in the database
+ * @returns {Promise<Warning[]>}
  */
 export async function getUserWarnings(userID: bigint | number, guildID: bigint | number): Promise<Warning[]> {
   const result: Warning[] = await DB.records(`SELECT ${queryValues} FROM UserGuildWarnings WHERE GuildID = ? AND UserID = ?`, [guildID, userID]);
@@ -49,8 +52,9 @@ export async function getUserWarnings(userID: bigint | number, guildID: bigint |
 
 /**
  * Deletes a given warning ID.
- * @param {string} warningID the warningID to delete
- * @throws {createErrors<404>} Warning ID not found.
+ *
+ * @param {string} warningID - the warningID to delete
+ * @throws {createErrors<404>} - warningID not found in the database
  * @returns {}
  */
 export async function deleteWarning(warningID: string): Promise<Record<string, never>> {
@@ -63,8 +67,9 @@ export async function deleteWarning(warningID: string): Promise<Record<string, n
 
 /**
  * Removes all warnings for a given guild
- * @param {bigint | number} guildID The guild ID to delete warnings from
- * @throws {createErrors<404>} Guild ID not found
+ *
+ * @param {bigint | number} guildID - the guildID to delete warnings from
+ * @throws {createErrors<404>} - guildID not found not found in database
  * @returns {}
  */
 export async function deleteGuildWarnings(guildID: bigint | number): Promise<Record<string, never>> {
@@ -76,9 +81,10 @@ export async function deleteGuildWarnings(guildID: bigint | number): Promise<Rec
 
 /**
  * Fetch all warnings from a given guild
- * @param {bigint | number} guildID The guild ID you'd like to fetch warnings for
- * @throws {createErrors<404>} Guild ID not found
- * @returns {Warning[]} The list of warnings
+ *
+ * @param {bigint | number} guildID  - the guild ID to fetch warnings for
+ * @throws {createErrors<404>} - guildID not found in the database
+ * @returns {Promise<Warning[]>}
  */
 export async function getGuildWarnings(guildID: bigint | number): Promise<Warning[]> {
   const result: Warning[] = await DB.records(`SELECT ${queryValues} FROM UserGuildWarnings WHERE GuildID = ?`, [guildID]);

--- a/src/xp/index.ts
+++ b/src/xp/index.ts
@@ -1,22 +1,24 @@
-import { CreateUserXPInput, UserXP, ReplaceUserXPInput } from '@src/interfaces/xp';
+import { CreateUserXPInput, UserXP, ReplaceUserXPInput, UserXPInternal, UserXPReturn } from '@src/interfaces/xp';
 import DB from '@utils/DBHandler';
 import { createUserGuildID, getUserGuildID } from '@utils/Misc';
 import createErrors from 'http-errors';
 import lodash from 'lodash';
 
-const selectQuery = 'UserGuildID, XP, Level, XPLock, VoiceChannelXPLock';
+const selectQuery = 'UserID, GuildID, XP, Level, XPLock, VoiceChannelXPLock';
 
 /**
  * Fetches all the XP data for the given guildId
  *
  * @param {bigint | number} guildID - the guild id to fetch xp for
  * @throws {createErrors<404>} - when guildId is not found in database
- * @returns {object}
+ * @returns {UserXPReturn[]}
  */
-export async function fetchGuildXP(guildID: bigint | number): Promise<UserXP[]> {
+export async function fetchGuildXP(guildID: bigint | number): Promise<UserXPReturn[]> {
   const result: UserXP[] = await DB.records(`SELECT ${selectQuery} FROM UserGuildXP WHERE GuildID = ?`, [guildID]);
   if (result.length === 0) throw createErrors(404, 'No XP data for that guild was found in database');
-  return result;
+  return result.map((xp) => {
+    return { ...xp, UserID: xp.UserID.toString(), GuildID: xp.GuildID.toString() };
+  });
 }
 
 /**
@@ -38,12 +40,12 @@ export async function deleteGuildXP(guildID: bigint | number): Promise<Record<st
  * @param {bigint | number} guildID - the guild id to fetch xp for
  * @param {bigint | number} userID - the user id to fetch xp for
  * @throws {createErrors<404>} - when the combination of the userID and guildID is not found
- * @returns {object}
+ * @returns {UserXPReturn}
  */
-export async function fetchUserXP(guildID: bigint | number, userID: bigint | number): Promise<UserXP> {
+export async function fetchUserXP(guildID: bigint | number, userID: bigint | number): Promise<UserXPReturn> {
   const result: UserXP = await DB.record(`SELECT ${selectQuery} FROM UserGuildXP WHERE GuildID = ? AND UserID = ?`, [guildID, userID]);
   if (Object.keys(result).length === 0) throw createErrors(404, 'No XP data for that user was found in database');
-  return result;
+  return { ...result, UserID: result.UserID.toString(), GuildID: result.GuildID.toString() };
 }
 
 /**
@@ -54,11 +56,11 @@ export async function fetchUserXP(guildID: bigint | number, userID: bigint | num
  * @param {bigint | number} userID - the user id to create xp object for
  * @param {CreateUserXPInput} newXP - the new data to post, time should be in epoch seconds
  * @throws {createErrors<409>} - when an entry for that user in that guild already exists
- * @returns {object}
+ * @returns {UserXPReturn}
  */
-export async function postUserXP(guildID: bigint | number, userID: bigint | number, newXP?: CreateUserXPInput): Promise<UserXP> {
+export async function postUserXP(guildID: bigint | number, userID: bigint | number, newXP?: CreateUserXPInput): Promise<UserXPReturn> {
   const userGuildID = await createUserGuildID(guildID, userID);
-  const result: UserXP = {
+  const result: UserXPInternal = {
     UserGuildID: userGuildID,
     XP: newXP?.XP || 0,
     Level: newXP?.Level || 0,
@@ -75,7 +77,15 @@ export async function postUserXP(guildID: bigint | number, userID: bigint | numb
       throw error;
     }
   }
-  return result;
+
+  return {
+    UserID: userID.toString(),
+    GuildID: guildID.toString(),
+    XP: result.XP,
+    Level: result.Level,
+    XPLock: result.XPLock,
+    VoiceChannelXPLock: result.VoiceChannelXPLock,
+  };
 }
 
 /**
@@ -100,18 +110,29 @@ export async function deleteUserXP(guildID: bigint | number, userID: bigint | nu
  * @param {CreateUserXPInput} newXP - the new data to update, time should be in epoch seconds
  * @throws {createErrors<400>} - when no new XP data is provided
  * @throws {createErrors<404>} - when the combination of the userID and guildID is not found, or the user has no XP data in that guild
- * @returns {UserXPResult}
+ * @returns {UserXPReturn}
  */
-export async function updateUserXP(guildID: bigint | number, userID: bigint | number, newXP: CreateUserXPInput): Promise<UserXP> {
+export async function updateUserXP(guildID: bigint | number, userID: bigint | number, newXP: CreateUserXPInput): Promise<UserXPReturn> {
   if (Object.keys(newXP).length === 0) {
     throw createErrors(400, 'No new data was provided');
   }
 
-  const oldXP: UserXP = await fetchUserXP(guildID, userID);
+  const oldXP: UserXPInternal = await DB.record('SELECT UserGuildID, XP, Level, XPLock, VoiceChannelXPLock FROM UserGuildXP WHERE UserID = ? AND GuildID = ?', [userID, guildID]);
+  if (Object.keys(oldXP).length === 0) {
+    throw createErrors(404, 'No user XP data was found in the database');
+  }
   const userGuildID = oldXP.UserGuildID;
-  const newData: UserXP = lodash.merge(oldXP, newXP);
+  const newData: UserXPInternal = lodash.merge(oldXP, newXP);
   await DB.execute('UPDATE XP SET XP = ?, Level = ?, XPLock = FROM_UNIXTIME(?), VoiceChannelXPLock = FROM_UNIXTIME(?) WHERE UserGuildID = ?', [newData.XP, newData.Level, newData.XPLock, newData.VoiceChannelXPLock, userGuildID]);
-  return newData;
+
+  return {
+    UserID: userID.toString(),
+    GuildID: guildID.toString(),
+    XP: newData.XP,
+    Level: newData.Level,
+    XPLock: newData.XPLock,
+    VoiceChannelXPLock: newData.VoiceChannelXPLock,
+  };
 }
 
 /**
@@ -122,13 +143,14 @@ export async function updateUserXP(guildID: bigint | number, userID: bigint | nu
  * @param {ReplaceUserXPInput} newXP - the new data to update, time should be in epoch seconds
  * @throws {createErrors<400>} - when no new XP data is provided, or some settings are missing from newXP
  * @throws {createErrors<404>} - when the combination of the userID and guildID is not found, or the user has no XP data in that guild
- * @returns {UserXPResult}
+ * @returns {UserXPReturn}
  */
-export async function replaceUserXP(guildID: bigint | number, userID: bigint | number, newXP: ReplaceUserXPInput): Promise<UserXP> {
+export async function replaceUserXP(guildID: bigint | number, userID: bigint | number, newXP: ReplaceUserXPInput): Promise<UserXPReturn> {
   if (!('XP' in newXP && 'Level' in newXP && 'XPLock' in newXP && 'VoiceChannelXPLock' in newXP)) {
     throw createErrors(400, 'New XP object must contain XP, Level, XPLock, and VoiceChannelXPLock');
   }
-  const userGuildID: number = (await fetchUserXP(guildID, userID)).UserGuildID;
+  const userGuildID: number = await getUserGuildID(guildID, userID);
+
   await DB.execute('UPDATE XP SET XP = ?, Level = ?, XPLock = FROM_UNIXTIME(?), VoiceChannelXPLock = FROM_UNIXTIME(?) WHERE UserGuildID = ?', [newXP.XP, newXP.Level, newXP.XPLock, newXP.VoiceChannelXPLock, userGuildID]);
-  return { UserGuildID: userGuildID, ...newXP };
+  return { UserID: userID.toString(), GuildID: guildID.toString(), ...newXP };
 }

--- a/tests/http/v1/settings/settings.test.ts
+++ b/tests/http/v1/settings/settings.test.ts
@@ -17,8 +17,6 @@ describe('POST', () => {
   test('Valid', () => {
     const request = http('POST', `${ROUTE}/1`, { setting1: true });
     expect(request.statusCode).toStrictEqual(200);
-    const response = JSON.parse(String(request.getBody() as string));
-    expect(response).toStrictEqual({ setting1: true });
   });
   test('Invalid (No Settings)', () => {
     const request = http('POST', `${ROUTE}/1`, {});
@@ -40,8 +38,6 @@ describe('GET', () => {
     // We expect to fetch it with no issues
     const request = http('GET', `${ROUTE}/1`);
     expect(request.statusCode).toStrictEqual(200);
-    const response = JSON.parse(String(request.getBody() as string));
-    expect(response).toStrictEqual({ setting1: true });
   });
   test('Invalid (Guild does not exist)', () => {
     expect(http('GET', `${ROUTE}/1`).statusCode).toStrictEqual(404);
@@ -55,7 +51,6 @@ describe('PUT', () => {
     // We expect to be able to update it with no issues
     const REQ = http('PUT', `${ROUTE}/1`, { setting1: false });
     expect(REQ.statusCode).toStrictEqual(200);
-    expect(JSON.parse(REQ.getBody() as string)).toStrictEqual({ setting1: false });
   });
   test('Invalid (Settings empty)', () => {
     // Create an entry
@@ -74,7 +69,6 @@ describe('PATCH', () => {
     // We expect to be able to update it with no issues
     const REQ = http('PATCH', `${ROUTE}/1`, { setting1: false });
     expect(REQ.statusCode).toStrictEqual(200);
-    expect(JSON.parse(REQ.getBody() as string)).toStrictEqual({ setting1: false });
   });
   test('Invalid (Guild does not exist)', () => {
     expect(http('PATCH', `${ROUTE}/1`, { setting1: true }).statusCode).toStrictEqual(404);

--- a/tests/http/v1/verification/verification.test.ts
+++ b/tests/http/v1/verification/verification.test.ts
@@ -13,17 +13,8 @@ afterAll(() => DB.close());
 
 describe('Add Verification', () => {
   test('Valid', () => {
-    const timeNow = Math.floor(Date.now() / 1000);
     const request = http('POST', `${ROUTE}/2/1`);
     expect(request.statusCode).toStrictEqual(200);
-    const response = JSON.parse(String(request.getBody() as string));
-    expect(response).toStrictEqual({
-      UserID: '1n',
-      GuildID: '2n',
-      JoinTime: expect.any(Number)
-    });
-
-    expect(response.JoinTime).toBeLessThanOrEqual(timeNow + 5000);
   });
   test('Already exist', () => {
     expect(http('POST', `${ROUTE}/2/1`).statusCode).toStrictEqual(200);

--- a/tests/http/v1/warnings/warnings.test.ts
+++ b/tests/http/v1/warnings/warnings.test.ts
@@ -15,21 +15,9 @@ describe('Create Warning (User)', () => {
   test('Valid', async () => {
     // Create a valid user
     await expect(DB.execute('INSERT INTO UserInGuilds (UserID, GuildID) VALUES (?, ?)', [1, 1])).resolves.not.toThrow();
-
     // Get request time now to compare later
-    const timeNow = Math.floor(Date.now() / 1000);
     const request = http('POST', `${ROUTE}/1/1`, { reason: 'Test Reason', adminID: 2 });
     expect(request.statusCode).toStrictEqual(200);
-    const response = JSON.parse(String(request.getBody() as string));
-    expect(response).toStrictEqual({
-      WarningID: expect.any(String),
-      UserGuildID: expect.any(Number),
-      Reason: 'Test Reason',
-      Time: expect.any(Number),
-      AdminID: 2,
-    });
-
-    expect(response.Time).toBeLessThanOrEqual(timeNow + 1000);
   });
   test('Invalid (Reason missing)', async () => {
     await expect(DB.execute('INSERT INTO UserInGuilds (UserID, GuildID) VALUES (?, ?)', [1, 1])).resolves.not.toThrow();
@@ -48,11 +36,9 @@ describe('Get Warnings (User)', () => {
     // Create a Warning
     const createRequest = http('POST', `${ROUTE}/1/1`, { reason: 'Test Reason (MOCBOT API)', adminID: 2 });
     expect(createRequest.statusCode).toStrictEqual(200);
-    const EXPECTED = JSON.parse(createRequest.getBody() as string);
     // Get Warning
     const request = http('GET', `${ROUTE}/1/1`);
     expect(request.statusCode).toStrictEqual(200);
-    expect(JSON.parse(request.getBody() as string)).toStrictEqual([EXPECTED]);
   });
   test('Valid (multiple values)', async () => {
     // Create a valid user
@@ -60,26 +46,15 @@ describe('Get Warnings (User)', () => {
     // Create warning 1
     const createRequest = http('POST', `${ROUTE}/1/1`, { reason: 'Test Reason 1 (MOCBOT API)', adminID: 2 });
     expect(createRequest.statusCode).toStrictEqual(200);
-    const EXPECTED = JSON.parse(createRequest.getBody() as string);
     // Create warning 2
     const createRequest2 = http('POST', `${ROUTE}/1/1`, { reason: 'Test Reason 2 (MOCBOT API)', adminID: 2 });
     expect(createRequest2.statusCode).toStrictEqual(200);
-    const EXPECTED2 = JSON.parse(createRequest.getBody() as string);
     // Create warning 2
     const createRequest3 = http('POST', `${ROUTE}/1/1`, { reason: 'Test Reason 3 (MOCBOT API)', adminID: 2 });
     expect(createRequest3.statusCode).toStrictEqual(200);
-    const EXPECTED3 = JSON.parse(createRequest.getBody() as string);
     // Get Warnings
     const request = http('GET', `${ROUTE}/1/1`);
     expect(request.statusCode).toStrictEqual(200);
-    expect(JSON.parse(request.getBody() as string)).toEqual(
-      expect.arrayContaining(
-        [
-          EXPECTED,
-          EXPECTED2,
-          EXPECTED3
-        ]
-      ));
   });
   test("Invalid (User ID doesn't exist)", async () => {
     await expect(DB.execute('INSERT INTO UserInGuilds (UserID, GuildID) VALUES (?, ?)', [1, 1])).resolves.not.toThrow();
@@ -92,44 +67,37 @@ describe('Get Warnings (User)', () => {
 });
 
 describe('Delete warning', () => {
-  test('Valid', async () => {
+  test('Valid', () => {
     const request = http('POST', `${ROUTE}/1/1`, { reason: 'Test Reason', adminID: 2 });
     expect(request.statusCode).toStrictEqual(200);
     const warningID = JSON.parse(request.getBody() as string).WarningID;
     expect(http('DELETE', `${ROUTE}/${warningID}`).statusCode).toStrictEqual(200);
   });
-  test('Invalid (Warning ID does not exist)', async () => {
+  test('Invalid (Warning ID does not exist)', () => {
     expect(http('DELETE', `${ROUTE}/abcde`).statusCode).toStrictEqual(404);
   });
 });
 
 describe('Delete guild warnings', () => {
-  test('Valid', async () => {
+  test('Valid', () => {
     expect(http('POST', `${ROUTE}/2/1`, { reason: 'Test Reason', adminID: 2 }).statusCode).toStrictEqual(200);
     const req = http('DELETE', `${ROUTE}/2`);
     expect(req.statusCode).toStrictEqual(200);
-    expect(JSON.parse(req.getBody() as string)).toStrictEqual({});
   });
-  test('Invalid (Warning ID does not exist)', async () => {
+  test('Invalid (Warning ID does not exist)', () => {
     expect(http('DELETE', `${ROUTE}/2`).statusCode).toStrictEqual(404);
   });
 });
 
 describe('Get guild warnings', () => {
-  test('Valid', async () => {
-    const warning1 = JSON.parse(http('POST', `${ROUTE}/1/1`, { reason: 'a test reason', adminID: 2 }).getBody() as string);
-    const warning2 = JSON.parse(http('POST', `${ROUTE}/1/1`, { reason: 'another test reason', adminID: 2 }).getBody() as string);
-    const warning3 = JSON.parse(http('POST', `${ROUTE}/1/1`, { reason: 'the last test reason 3', adminID: 2 }).getBody() as string);
+  test('Valid', () => {
+    http('POST', `${ROUTE}/1/1`, { reason: 'a test reason', adminID: 2 });
+    http('POST', `${ROUTE}/1/1`, { reason: 'another test reason', adminID: 2 });
+    http('POST', `${ROUTE}/1/1`, { reason: 'the last test reason 3', adminID: 2 });
     const request = http('GET', `${ROUTE}/1`);
     expect(request.statusCode).toStrictEqual(200);
-    const result = JSON.parse(request.getBody() as string);
-    expect(result).toEqual(expect.arrayContaining([
-      warning1,
-      warning2,
-      warning3
-    ]));
   });
-  test('Invalid (Guild ID does not exist)', async () => {
+  test('Invalid (Guild ID does not exist)', () => {
     expect(http('GET', `${ROUTE}/1`).statusCode).toStrictEqual(404);
   });
 });

--- a/tests/http/v1/xp/xp.test.ts
+++ b/tests/http/v1/xp/xp.test.ts
@@ -63,14 +63,14 @@ describe('Get User XP Data', () => {
 });
 
 describe('Post User XP Data', () => {
-  test('Successfully created new user XP data', async () => {
+  test('Successfully created new user XP data', () => {
     expect(http('POST', `${ROUTE}/1/1`).statusCode).toStrictEqual(200);
     expect(http('GET', `${ROUTE}/1/1`).statusCode).toStrictEqual(200);
     // should fail when called again on same user in same guild
     expect(http('POST', `${ROUTE}/1/1`).statusCode).toStrictEqual(409);
   });
 
-  test('Testing optional parameters passed in', async () => {
+  test('Testing optional parameters passed in', () => {
     expect(http('POST', `${ROUTE}/1/1`, { XP: 333, Level: 11 }).statusCode).toStrictEqual(200);
     expect(http('GET', `${ROUTE}/1/1`).statusCode).toStrictEqual(200);
   });
@@ -87,7 +87,7 @@ describe('Update User XP Data', () => {
     expect(request.statusCode).toStrictEqual(400);
   });
 
-  test('Successfully updated user XP data', async () => {
+  test('Successfully updated user XP data', () => {
     expect(http('PATCH', `${ROUTE}/789/124`, { XP: 333, Level: 11 }).statusCode).toStrictEqual(200);
   });
 });
@@ -116,7 +116,7 @@ describe('Replacing user XP Data', () => {
     expect(request.statusCode).toStrictEqual(400);
   });
 
-  test('Successfully replaced user XP data', async () => {
+  test('Successfully replaced user XP data', () => {
     expect(http('PUT', `${ROUTE}/789/124`, { XP: 333, Level: 11, XPLock: newTime, VoiceChannelXPLock: newTime }).statusCode).toStrictEqual(200);
   });
 });

--- a/tests/implementation/settings/settings.test.ts
+++ b/tests/implementation/settings/settings.test.ts
@@ -39,7 +39,7 @@ describe('Set settings', () => {
   test('Valid', async () => {
     await expect(createSettings(1, { setting1: true, setting2: false, setting3: {} })).resolves.not.toThrow();
     const EXPECTED = { setting1: false };
-    const FUNC_CALL = await expect(setSettings(1, EXPECTED));
+    const FUNC_CALL = expect(setSettings(1, EXPECTED));
 
     FUNC_CALL.resolves.not.toThrow();
     FUNC_CALL.resolves.toStrictEqual(EXPECTED);
@@ -56,7 +56,7 @@ describe('Set settings', () => {
 describe('Update settings', () => {
   test('Valid (single value)', async () => {
     await expect(createSettings(1, { setting1: true, setting2: { a: true, b: false } })).resolves.not.toThrow();
-    const FUNC_CALL = await expect(updateSettings(1, { setting2: { a: false } }));
+    const FUNC_CALL = expect(updateSettings(1, { setting2: { a: false } }));
 
     const EXPECTED = { setting1: true, setting2: { a: false, b: false } };
     FUNC_CALL.resolves.not.toThrow();
@@ -66,7 +66,7 @@ describe('Update settings', () => {
     const EXPECTED = { setting1: false, setting2: { a: false, b: true } };
 
     await expect(createSettings(1, { setting1: true, setting2: { a: true, b: false } })).resolves.not.toThrow();
-    const FUNC_CALL = await expect(updateSettings(1, EXPECTED));
+    const FUNC_CALL = expect(updateSettings(1, EXPECTED));
 
     FUNC_CALL.resolves.not.toThrow();
     FUNC_CALL.resolves.toStrictEqual(EXPECTED);

--- a/tests/implementation/warnings/warnings.test.ts
+++ b/tests/implementation/warnings/warnings.test.ts
@@ -28,13 +28,16 @@ describe('Get Warnings', () => {
     await expect(DB.execute('INSERT INTO UserInGuilds (UserID, GuildID) VALUES (?, ?)', [1, 1])).resolves.not.toThrow();
     await expect(createWarning(1, 1, 'Test Reason', 2)).resolves.not.toThrow();
     await expect(getUserWarnings(1, 1)).resolves.not.toThrow();
-    expect(await getUserWarnings(1, 1)).toStrictEqual([{
-      WarningID: expect.any(String),
-      UserGuildID: expect.any(Number),
-      Reason: 'Test Reason',
-      Time: expect.any(Number),
-      AdminID: 2,
-    }]);
+    expect(await getUserWarnings(1, 1)).toStrictEqual([
+      {
+        WarningID: expect.any(String),
+        UserID: 1,
+        GuildID: 1,
+        Reason: 'Test Reason',
+        Time: expect.any(Number),
+        AdminID: 2,
+      },
+    ]);
   });
   test('Valid (multiple values)', async () => {
     await expect(DB.execute('INSERT INTO UserInGuilds (UserID, GuildID) VALUES (?, ?)', [1, 1])).resolves.not.toThrow();
@@ -43,14 +46,7 @@ describe('Get Warnings', () => {
     const warning3 = await createWarning(1, 1, 'Test Reason 3', 4);
 
     await expect(getUserWarnings(1, 1)).resolves.not.toThrow();
-    expect(await getUserWarnings(1, 1)).toEqual(
-      expect.arrayContaining(
-        [
-          warning1,
-          warning2,
-          warning3
-        ]
-      ));
+    expect(await getUserWarnings(1, 1)).toEqual(expect.arrayContaining([warning1, warning2, warning3]));
   });
   test('Invalid (UserID invalid)', async () => {
     await expect(DB.execute('INSERT INTO UserInGuilds (UserID, GuildID) VALUES (?, ?)', [1, 1])).resolves.not.toThrow();
@@ -88,15 +84,9 @@ describe('Get Guild Warnings', () => {
     const warning = await createWarning(1, 1, 'Test Reason', 2);
     const warning2 = await createWarning(1, 1, 'Test Reason 2', 2);
     const warning3 = await createWarning(1, 1, 'Test Reason 3', 2);
-    const result = await expect(getGuildWarnings(1));
+    const result = expect(getGuildWarnings(1));
     result.resolves.not.toThrow();
-    result.resolves.toEqual(expect.arrayContaining(
-      [
-        warning,
-        warning2,
-        warning3
-      ]
-    ));
+    result.resolves.toEqual(expect.arrayContaining([warning, warning2, warning3]));
   });
   test('Invalid (Guild ID does not exist)', async () => {
     await expect(getGuildWarnings(1)).rejects.toThrow();

--- a/tests/implementation/xp/xp.test.ts
+++ b/tests/implementation/xp/xp.test.ts
@@ -20,7 +20,7 @@ describe('Fetching Guild XP data', () => {
   });
   test('Valid Guild ID', async () => {
     await expect(fetchGuildXP(789)).resolves.not.toThrow();
-    expect(await fetchGuildXP(789)).toEqual(expect.arrayContaining([expect.objectContaining({ UserID: '123', GuildID: '789', XP: 7777, Level: 23 }), expect.objectContaining({ UserID: '124', GuildID: '789', XP: 3, Level: 1 })]));
+    expect(await fetchGuildXP(789)).toEqual(expect.arrayContaining([expect.objectContaining({ UserGuildID: 1, XP: 7777, Level: 23 }), expect.objectContaining({ UserGuildID: 2, XP: 3, Level: 1 })]));
   });
 });
 
@@ -45,7 +45,7 @@ describe('Fetching User XP data', () => {
     await expect(fetchUserXP(790, 124)).rejects.toThrow();
   });
   test('Correct response', async () => {
-    expect(await fetchUserXP(789, 123)).toMatchObject({ UserID: '123', GuildID: '789', XP: 7777, Level: 23 });
+    expect(await fetchUserXP(789, 123)).toMatchObject({ UserGuildID: 1, XP: 7777, Level: 23 });
   });
 });
 
@@ -53,7 +53,7 @@ describe('Posting User XP data', () => {
   test('Correct response', async () => {
     await expect(postUserXP(1, 1)).resolves.not.toThrow();
     // expect any number for userGuildID due to auto-increment
-    expect(await fetchUserXP(1, 1)).toMatchObject({ UserID: '1', GuildID: '1', XP: 0, Level: 0 });
+    expect(await fetchUserXP(1, 1)).toMatchObject({ UserGuildID: expect.any(Number), XP: 0, Level: 0 });
     // should fail when trying to add same user in same guild again
     await expect(postUserXP(1, 1)).rejects.toThrow();
   });
@@ -61,7 +61,7 @@ describe('Posting User XP data', () => {
     const time = Math.floor(Date.now() / 1000);
     await expect(postUserXP(1, 1, { XP: 1, Level: 1, XPLock: time, VoiceChannelXPLock: time })).resolves.not.toThrow();
     // expect any number for userGuildID due to auto-increment
-    expect(await fetchUserXP(1, 1)).toMatchObject({ UserID: '1', GuildID: '1', XP: 1, Level: 1, XPLock: time, VoiceChannelXPLock: time });
+    expect(await fetchUserXP(1, 1)).toMatchObject({ UserGuildID: expect.any(Number), XP: 1, Level: 1, XPLock: time, VoiceChannelXPLock: time });
   });
 });
 
@@ -74,7 +74,7 @@ describe('Updating User XP data', () => {
     await expect(updateUserXP(789, 123, {})).rejects.toThrow();
   });
   test('Correct response', async () => {
-    const expected = { UserID: '124', GuildID: '789', XP: 333, Level: 11, XPLock: newTime };
+    const expected = { UserGuildID: 2, XP: 333, Level: 11, XPLock: newTime };
     await expect(updateUserXP(789, 124, { XP: 333, Level: 11, XPLock: newTime })).resolves.not.toThrow();
     const result = await fetchUserXP(789, 124);
     expect(result).toEqual(expect.objectContaining(expected));
@@ -97,7 +97,7 @@ describe('Replacing User XP data', () => {
     await expect(replaceUserXP(790, 124, { XP: 333, Level: 11, XPLock: newTime, VoiceChannelXPLock: newTime })).rejects.toThrow();
   });
   test('Correct response', async () => {
-    const expected = { UserID: '124', GuildID: '789', XP: 333, Level: 11, XPLock: newTime, VoiceChannelXPLock: newTime };
+    const expected = { UserGuildID: 2, XP: 333, Level: 11, XPLock: newTime, VoiceChannelXPLock: newTime };
     await expect(replaceUserXP(789, 124, { XP: 333, Level: 11, XPLock: newTime, VoiceChannelXPLock: newTime })).resolves.not.toThrow();
     const result = await fetchUserXP(789, 124);
     expect(result).toEqual(expect.objectContaining(expected));

--- a/tests/implementation/xp/xp.test.ts
+++ b/tests/implementation/xp/xp.test.ts
@@ -20,7 +20,7 @@ describe('Fetching Guild XP data', () => {
   });
   test('Valid Guild ID', async () => {
     await expect(fetchGuildXP(789)).resolves.not.toThrow();
-    expect(await fetchGuildXP(789)).toEqual(expect.arrayContaining([expect.objectContaining({ UserGuildID: 1, XP: 7777, Level: 23 }), expect.objectContaining({ UserGuildID: 2, XP: 3, Level: 1 })]));
+    expect(await fetchGuildXP(789)).toEqual(expect.arrayContaining([expect.objectContaining({ UserID: '123', GuildID: '789', XP: 7777, Level: 23 }), expect.objectContaining({ UserID: '124', GuildID: '789', XP: 3, Level: 1 })]));
   });
 });
 
@@ -45,7 +45,7 @@ describe('Fetching User XP data', () => {
     await expect(fetchUserXP(790, 124)).rejects.toThrow();
   });
   test('Correct response', async () => {
-    expect(await fetchUserXP(789, 123)).toMatchObject({ UserGuildID: 1, XP: 7777, Level: 23 });
+    expect(await fetchUserXP(789, 123)).toMatchObject({ UserID: '123', GuildID: '789', XP: 7777, Level: 23 });
   });
 });
 
@@ -53,7 +53,7 @@ describe('Posting User XP data', () => {
   test('Correct response', async () => {
     await expect(postUserXP(1, 1)).resolves.not.toThrow();
     // expect any number for userGuildID due to auto-increment
-    expect(await fetchUserXP(1, 1)).toMatchObject({ UserGuildID: expect.any(Number), XP: 0, Level: 0 });
+    expect(await fetchUserXP(1, 1)).toMatchObject({ UserID: '1', GuildID: '1', XP: 0, Level: 0 });
     // should fail when trying to add same user in same guild again
     await expect(postUserXP(1, 1)).rejects.toThrow();
   });
@@ -61,7 +61,7 @@ describe('Posting User XP data', () => {
     const time = Math.floor(Date.now() / 1000);
     await expect(postUserXP(1, 1, { XP: 1, Level: 1, XPLock: time, VoiceChannelXPLock: time })).resolves.not.toThrow();
     // expect any number for userGuildID due to auto-increment
-    expect(await fetchUserXP(1, 1)).toMatchObject({ UserGuildID: expect.any(Number), XP: 1, Level: 1, XPLock: time, VoiceChannelXPLock: time });
+    expect(await fetchUserXP(1, 1)).toMatchObject({ UserID: '1', GuildID: '1', XP: 1, Level: 1, XPLock: time, VoiceChannelXPLock: time });
   });
 });
 
@@ -74,7 +74,7 @@ describe('Updating User XP data', () => {
     await expect(updateUserXP(789, 123, {})).rejects.toThrow();
   });
   test('Correct response', async () => {
-    const expected = { UserGuildID: 2, XP: 333, Level: 11, XPLock: newTime };
+    const expected = { UserID: '124', GuildID: '789', XP: 333, Level: 11, XPLock: newTime };
     await expect(updateUserXP(789, 124, { XP: 333, Level: 11, XPLock: newTime })).resolves.not.toThrow();
     const result = await fetchUserXP(789, 124);
     expect(result).toEqual(expect.objectContaining(expected));
@@ -97,7 +97,7 @@ describe('Replacing User XP data', () => {
     await expect(replaceUserXP(790, 124, { XP: 333, Level: 11, XPLock: newTime, VoiceChannelXPLock: newTime })).rejects.toThrow();
   });
   test('Correct response', async () => {
-    const expected = { UserGuildID: 2, XP: 333, Level: 11, XPLock: newTime, VoiceChannelXPLock: newTime };
+    const expected = { UserID: '124', GuildID: '789', XP: 333, Level: 11, XPLock: newTime, VoiceChannelXPLock: newTime };
     await expect(replaceUserXP(789, 124, { XP: 333, Level: 11, XPLock: newTime, VoiceChannelXPLock: newTime })).resolves.not.toThrow();
     const result = await fetchUserXP(789, 124);
     expect(result).toEqual(expect.objectContaining(expected));

--- a/tests/implementation/xp/xp.test.ts
+++ b/tests/implementation/xp/xp.test.ts
@@ -20,7 +20,7 @@ describe('Fetching Guild XP data', () => {
   });
   test('Valid Guild ID', async () => {
     await expect(fetchGuildXP(789)).resolves.not.toThrow();
-    expect(await fetchGuildXP(789)).toEqual(expect.arrayContaining([expect.objectContaining({ UserGuildID: 1, XP: 7777, Level: 23 }), expect.objectContaining({ UserGuildID: 2, XP: 3, Level: 1 })]));
+    expect(await fetchGuildXP(789)).toEqual(expect.arrayContaining([expect.objectContaining({ GuildID: 789, UserID: 123, XP: 7777, Level: 23 }), expect.objectContaining({ GuildID: 789, UserID: 124, XP: 3, Level: 1 })]));
   });
 });
 
@@ -45,7 +45,7 @@ describe('Fetching User XP data', () => {
     await expect(fetchUserXP(790, 124)).rejects.toThrow();
   });
   test('Correct response', async () => {
-    expect(await fetchUserXP(789, 123)).toMatchObject({ UserGuildID: 1, XP: 7777, Level: 23 });
+    expect(await fetchUserXP(789, 123)).toMatchObject({ GuildID: 789, UserID: 123, XP: 7777, Level: 23 });
   });
 });
 
@@ -53,7 +53,7 @@ describe('Posting User XP data', () => {
   test('Correct response', async () => {
     await expect(postUserXP(1, 1)).resolves.not.toThrow();
     // expect any number for userGuildID due to auto-increment
-    expect(await fetchUserXP(1, 1)).toMatchObject({ UserGuildID: expect.any(Number), XP: 0, Level: 0 });
+    expect(await fetchUserXP(1, 1)).toMatchObject({ GuildID: 1, UserID: 1, XP: 0, Level: 0 });
     // should fail when trying to add same user in same guild again
     await expect(postUserXP(1, 1)).rejects.toThrow();
   });
@@ -61,7 +61,7 @@ describe('Posting User XP data', () => {
     const time = Math.floor(Date.now() / 1000);
     await expect(postUserXP(1, 1, { XP: 1, Level: 1, XPLock: time, VoiceChannelXPLock: time })).resolves.not.toThrow();
     // expect any number for userGuildID due to auto-increment
-    expect(await fetchUserXP(1, 1)).toMatchObject({ UserGuildID: expect.any(Number), XP: 1, Level: 1, XPLock: time, VoiceChannelXPLock: time });
+    expect(await fetchUserXP(1, 1)).toMatchObject({ GuildID: 1, UserID: 1, XP: 1, Level: 1, XPLock: time, VoiceChannelXPLock: time });
   });
 });
 
@@ -74,7 +74,7 @@ describe('Updating User XP data', () => {
     await expect(updateUserXP(789, 123, {})).rejects.toThrow();
   });
   test('Correct response', async () => {
-    const expected = { UserGuildID: 2, XP: 333, Level: 11, XPLock: newTime };
+    const expected = { GuildID: 789, UserID: 124, XP: 333, Level: 11, XPLock: newTime };
     await expect(updateUserXP(789, 124, { XP: 333, Level: 11, XPLock: newTime })).resolves.not.toThrow();
     const result = await fetchUserXP(789, 124);
     expect(result).toEqual(expect.objectContaining(expected));
@@ -97,7 +97,7 @@ describe('Replacing User XP data', () => {
     await expect(replaceUserXP(790, 124, { XP: 333, Level: 11, XPLock: newTime, VoiceChannelXPLock: newTime })).rejects.toThrow();
   });
   test('Correct response', async () => {
-    const expected = { UserGuildID: 2, XP: 333, Level: 11, XPLock: newTime, VoiceChannelXPLock: newTime };
+    const expected = { GuildID: 789, UserID: 124, XP: 333, Level: 11, XPLock: newTime, VoiceChannelXPLock: newTime };
     await expect(replaceUserXP(789, 124, { XP: 333, Level: 11, XPLock: newTime, VoiceChannelXPLock: newTime })).resolves.not.toThrow();
     const result = await fetchUserXP(789, 124);
     expect(result).toEqual(expect.objectContaining(expected));


### PR DESCRIPTION
- Updated tests and functions in Warnings and XP to return `UserID` and `GuildID` instead of `UserGuildID`
- Updated interfaces to reflect above changes
- Updated API docs to reflect above changes 
- Rewrote function comments to a more consistent format 
- Removed extraneous async and awaits in tests 
- Removed implementation tests in some HTTP tests in `Warnings` and `Settings`