### PR TITLE
Functions Return Strings for Numbers

### DIFF
--- a/docs/api.yml
+++ b/docs/api.yml
@@ -775,12 +775,10 @@ components:
           example: "1"
         XPLock:
           type: string
-          format: int64
           description: The Unix timestamp at which this user can start gaining XP from messages, in whole number of seconds
           example: "1671727778"
         VoiceChannelXPLock:
           type: string
-          format: int64
           description: The Unix timestamp at which this user can start gaining XP from voice activity, in whole number of seconds
           example: "1671727784"
     ReplaceUserXPInput:
@@ -796,12 +794,10 @@ components:
           example: "1"
         XPLock:
           type: string
-          format: int64
           description: The Unix timestamp at which this user can start gaining XP from messages, in whole number of seconds
           example: "1671727778"
         VoiceChannelXPLock:
           type: string
-          format: int64
           description: The Unix timestamp at which this user can start gaining XP from voice activity, in whole number of seconds
           example: "1671727784"
     GuildWarnings:
@@ -829,7 +825,6 @@ components:
           example: "Chat Spam"
         Time:
           type: string
-          format: int64
           description: The Unix timestamp at which the user was warned, in whole number of seconds
           example: "1671727778"
         AdminID:
@@ -875,7 +870,6 @@ components:
           example: "169402073404669952"
         JoinTime:
           type: string
-          format: int64
           description: The Unix timestamp at which the user was placed in Verification, in whole number of seconds
           example: "1671727778"
     VerificationUpdate:

--- a/docs/api.yml
+++ b/docs/api.yml
@@ -760,50 +760,50 @@ components:
         UserID:
           type: string
           description: The user ID
-          example: "1n"
+          example: "1"
         GuildID:
           type: string
           description: The guild ID of the user
-          example: "1n"
+          example: "1"
         XP:
-          type: integer
+          type: string
           description: The current XP value
-          example: 100
+          example: "100"
         Level:
-          type: integer
+          type: string
           description: The current level
-          example: 1
+          example: "1"
         XPLock:
-          type: integer
+          type: string
           format: int64
           description: The Unix timestamp at which this user can start gaining XP from messages, in whole number of seconds
-          example: 1671727778
+          example: "1671727778"
         VoiceChannelXPLock:
-          type: integer
+          type: string
           format: int64
           description: The Unix timestamp at which this user can start gaining XP from voice activity, in whole number of seconds
-          example: 1671727784
+          example: "1671727784"
     ReplaceUserXPInput:
       type: object
       properties:
         XP:
-          type: integer
+          type: string
           description: The new XP value
-          example: 100
+          example: "100"
         Level:
-          type: integer
+          type: string
           description: The new level
-          example: 1
+          example: "1"
         XPLock:
-          type: integer
+          type: string
           format: int64
           description: The Unix timestamp at which this user can start gaining XP from messages, in whole number of seconds
-          example: 1671727778
+          example: "1671727778"
         VoiceChannelXPLock:
-          type: integer
+          type: string
           format: int64
           description: The Unix timestamp at which this user can start gaining XP from voice activity, in whole number of seconds
-          example: 1671727784
+          example: "1671727784"
     GuildWarnings:
       type: array
       items:
@@ -818,24 +818,24 @@ components:
         UserID:
           type: string
           description: The User ID of the warning
-          example: "1n"
+          example: "1"
         GuildID:
           type: string
           description: The Guild ID where the warning was issued
-          example: "1n"
+          example: "1"
         Reason:
           type: string
           description: The reason behind the warning
           example: "Chat Spam"
         Time:
-          type: integer
+          type: string
           format: int64
           description: The Unix timestamp at which the user was warned, in whole number of seconds
-          example: 1671727778
+          example: "1671727778"
         AdminID:
-          type: integer
+          type: string
           description: The ID of the administrator who distributed the warning
-          example: 381
+          example: "381"
     UserWarnings:
       type: array
       items:
@@ -848,9 +848,9 @@ components:
           description: The reason behind the warning
           example: "Chat Spamming"
         adminID:
-          type: integer
+          type: string
           description: The ID of the administrator who distributed the warning
-          example: 124
+          example: "124"
     Settings:
       type: object
       example:
@@ -860,52 +860,52 @@ components:
     UserXPRequest:
       type: object
       example:
-        XP: 100
-        VoiceChannelXPLock: 16717274013
+        XP: "100"
+        VoiceChannelXPLock: "16717274013"
     Verification:
       type: object
       properties:
         UserID:
           type: string
           description: The ID of the user
-          example: 231230403053092864n
+          example: "231230403053092864"
         GuildID:
           type: string
           description: The ID of the guild the user is in
-          example: 169402073404669952n
+          example: "169402073404669952"
         JoinTime:
-          type: integer
+          type: string
           format: int64
           description: The Unix timestamp at which the user was placed in Verification, in whole number of seconds
-          example: 1671727778
+          example: "1671727778"
     VerificationUpdate:
       type: object
       properties:
         MessageID:
-          type: integer
+          type: string
           description: The ID of the lock down approval message
-          example: 1056206377569222656
+          example: "1056206377569222656"
         ChannelID:
-          type: integer
+          type: string
           description: The ID of the lock down approvals channel
-          example: 673449065593438238
+          example: "673449065593438238"
     AFKRequest:
       type: object
       properties:
         MessageID:
-          type: integer
+          type: string
           description: The Message ID of the AFK message sent by the bot
-          example: 1056206377569222656
+          example: "1056206377569222656"
         ChannelID:
-          type: integer
+          type: string
           description: The Channel ID of the AFK message sent by the bot
-          example: 673449065593438238
+          example: "673449065593438238"
         OldName:
           type: string
           description: The old name of the user
           example: "A"
         Reason:
-          type: integer
+          type: string
           description: The reason for the user being AFK
           example: "B"
     AFK:
@@ -914,25 +914,25 @@ components:
         UserID:
           type: string
           description: The ID of the user
-          example: "231230403053092864n"
+          example: "231230403053092864"
         GuildID:
           type: string
           description: The ID of the guild the user is in
-          example: "169402073404669952n"
+          example: "169402073404669952"
         MessageID:
-          type: integer
+          type: string
           description: The Message ID of the AFK message sent by the bot
-          example: "1056206377569222656n"
+          example: "1056206377569222656"
         ChannelID:
-          type: integer
+          type: string
           description: The Channel ID of the AFK message sent by the bot
-          example: "673449065593438238n"
+          example: "673449065593438238"
         OldName:
           type: string
           description: The old name of the user
           example: "A"
         Reason:
-          type: integer
+          type: string
           description: The reason for the user being AFK
           example: "B"
 security:

--- a/src/afk/index.ts
+++ b/src/afk/index.ts
@@ -43,10 +43,10 @@ export async function insertAFK(userID: bigint | number, guildID: bigint | numbe
     }
   }
   return {
-    UserID: userID,
-    GuildID: guildID,
-    MessageID: data.MessageID,
-    ChannelID: data.ChannelID,
+    UserID: userID.toString(),
+    GuildID: guildID.toString(),
+    MessageID: data.MessageID.toString(),
+    ChannelID: data.ChannelID.toString(),
     OldName: data.OldName,
     Reason: data.Reason,
   };

--- a/src/interfaces/afk.ts
+++ b/src/interfaces/afk.ts
@@ -1,8 +1,8 @@
 export interface AFK {
-  UserID: bigint | number;
-  GuildID: bigint | number;
-  MessageID: bigint | number;
-  ChannelID: bigint | number;
+  UserID: string;
+  GuildID: string;
+  MessageID: string;
+  ChannelID: string;
   OldName: string;
   Reason: string;
 }

--- a/src/interfaces/verification.ts
+++ b/src/interfaces/verification.ts
@@ -1,12 +1,12 @@
 export interface Verification {
-    UserID: bigint | number,
-    GuildID: bigint | number,
-    MessageID?: bigint | number,
-    ChannelID?: bigint | number,
-    JoinTime: number
+  UserID: string;
+  GuildID: string;
+  MessageID?: string;
+  ChannelID?: string;
+  JoinTime: string;
 }
 
 export interface LockdownInput {
-    MessageID?: bigint | number,
-    ChannelID?: bigint | number
+  MessageID?: bigint | number;
+  ChannelID?: bigint | number;
 }

--- a/src/interfaces/warnings.ts
+++ b/src/interfaces/warnings.ts
@@ -1,8 +1,8 @@
 export interface Warning {
   WarningID: string;
-  UserID: bigint | number;
-  GuildID: bigint | number;
+  UserID: string;
+  GuildID: string;
   Reason: string;
-  Time: number;
-  AdminID: bigint | number;
+  Time: string;
+  AdminID: string;
 }

--- a/src/interfaces/xp.ts
+++ b/src/interfaces/xp.ts
@@ -1,10 +1,10 @@
 export interface UserXP {
-  UserID: bigint | number;
-  GuildID: bigint | number;
-  XP: number;
-  Level: number;
-  XPLock: number;
-  VoiceChannelXPLock: number;
+  UserID: string;
+  GuildID: string;
+  XP: string;
+  Level: string;
+  XPLock: string;
+  VoiceChannelXPLock: string;
 }
 
 export interface CreateUserXPInput {

--- a/src/utils/DBHandler/index.ts
+++ b/src/utils/DBHandler/index.ts
@@ -6,6 +6,8 @@ class DatabaseHandler {
     user: process.env.DB_USER,
     password: process.env.DB_PASS,
     database: process.env.DB_NAME,
+    supportBigNumbers: true,
+    bigNumberStrings: true,
   });
 
   /**

--- a/src/verification/index.ts
+++ b/src/verification/index.ts
@@ -27,9 +27,9 @@ export async function addVerification(userID: bigint | number, guildID: bigint |
     }
   }
   return {
-    UserID: userID,
-    GuildID: guildID,
-    JoinTime: TIME,
+    UserID: userID.toString(),
+    GuildID: guildID.toString(),
+    JoinTime: TIME.toString(),
   };
 }
 

--- a/src/warnings/index.ts
+++ b/src/warnings/index.ts
@@ -26,11 +26,11 @@ export async function createWarning(userID: bigint | number, guildID: bigint | n
   const userGuildID: number = await createUserGuildID(guildID, userID);
   const RESULT: Warning = {
     WarningID: uuidv4(),
-    UserID: userID,
-    GuildID: guildID,
+    UserID: userID.toString(),
+    GuildID: guildID.toString(),
     Reason: reason,
-    Time: Math.floor(Date.now() / 1000),
-    AdminID: adminID,
+    Time: Math.floor(Date.now() / 1000).toString(),
+    AdminID: adminID.toString(),
   };
   await DB.execute('INSERT INTO Warnings (WarningID, UserGuildID, Reason, Time, AdminID) VALUES (?, ?, ?, FROM_UNIXTIME(?), ?)', [RESULT.WarningID, userGuildID, RESULT.Reason, RESULT.Time, RESULT.AdminID]);
   return RESULT;

--- a/src/xp/index.ts
+++ b/src/xp/index.ts
@@ -59,12 +59,12 @@ export async function fetchUserXP(guildID: bigint | number, userID: bigint | num
 export async function postUserXP(guildID: bigint | number, userID: bigint | number, newXP?: CreateUserXPInput): Promise<UserXP> {
   const userGuildID = await createUserGuildID(guildID, userID);
   const result: UserXP = {
-    UserID: userID,
-    GuildID: guildID,
-    XP: newXP?.XP || 0,
-    Level: newXP?.Level || 0,
-    XPLock: newXP?.XPLock || Math.floor(Date.now() / 1000),
-    VoiceChannelXPLock: newXP?.VoiceChannelXPLock || Math.floor(Date.now() / 1000),
+    UserID: userID.toString(),
+    GuildID: guildID.toString(),
+    XP: (newXP?.XP || 0).toString(),
+    Level: (newXP?.Level || 0).toString(),
+    XPLock: (newXP?.XPLock || Math.floor(Date.now() / 1000)).toString(),
+    VoiceChannelXPLock: (newXP?.VoiceChannelXPLock || Math.floor(Date.now() / 1000)).toString(),
   };
 
   try {
@@ -131,5 +131,5 @@ export async function replaceUserXP(guildID: bigint | number, userID: bigint | n
   }
   const userGuildID: number = await getUserGuildID(guildID, userID, 'UserGuildXP');
   await DB.execute('UPDATE XP SET XP = ?, Level = ?, XPLock = FROM_UNIXTIME(?), VoiceChannelXPLock = FROM_UNIXTIME(?) WHERE UserGuildID = ?', [newXP.XP, newXP.Level, newXP.XPLock, newXP.VoiceChannelXPLock, userGuildID]);
-  return { UserID: userID, GuildID: guildID, ...newXP };
+  return { UserID: userID.toString(), GuildID: guildID.toString(), XP: newXP.XP.toString(), Level: newXP.Level.toString(), XPLock: newXP.XPLock.toString(), VoiceChannelXPLock: newXP.VoiceChannelXPLock.toString() };
 }

--- a/tests/implementation/afk/afk.test.ts
+++ b/tests/implementation/afk/afk.test.ts
@@ -13,23 +13,23 @@ afterEach(async () => {
 afterAll(() => DB.close());
 
 const VALID_AFK_DATA = {
-  MessageID: 1056206377569222700,
-  ChannelID: 673449065593438200,
+  MessageID: BigInt('1056206377569222700'),
+  ChannelID: BigInt('673449065593438200'),
   OldName: 'A',
   Reason: 'B',
 };
 
 describe('Add a user into AFK', () => {
   const AFKData = {
-    MessageID: 1056206377569222700,
-    ChannelID: 673449065593438200,
+    MessageID: BigInt('1056206377569222700'),
+    ChannelID: BigInt('673449065593438200'),
   };
   test('Valid', async () => {
     expect(await insertAFK(1, 2, VALID_AFK_DATA)).toStrictEqual({
-      UserID: 1,
-      GuildID: 2,
-      MessageID: VALID_AFK_DATA.MessageID,
-      ChannelID: VALID_AFK_DATA.ChannelID,
+      UserID: '1',
+      GuildID: '2',
+      MessageID: VALID_AFK_DATA.MessageID.toString(),
+      ChannelID: VALID_AFK_DATA.ChannelID.toString(),
       OldName: VALID_AFK_DATA.OldName,
       Reason: VALID_AFK_DATA.Reason,
     });
@@ -51,10 +51,10 @@ describe('Get AFKData', () => {
     await insertAFK(1, 2, VALID_AFK_DATA);
 
     expect(await getAFK(1, 2)).toStrictEqual({
-      UserID: 1,
-      GuildID: 2,
-      MessageID: VALID_AFK_DATA.MessageID,
-      ChannelID: VALID_AFK_DATA.ChannelID,
+      UserID: '1',
+      GuildID: '2',
+      MessageID: VALID_AFK_DATA.MessageID.toString(),
+      ChannelID: VALID_AFK_DATA.ChannelID.toString(),
       OldName: VALID_AFK_DATA.OldName,
       Reason: VALID_AFK_DATA.Reason,
     });

--- a/tests/implementation/verification/verification.test.ts
+++ b/tests/implementation/verification/verification.test.ts
@@ -16,9 +16,9 @@ describe('addVerification()', () => {
   test('Valid', async () => {
     const result = await addVerification(1, 2);
     expect(result).toStrictEqual({
-      UserID: 1,
-      GuildID: 2,
-      JoinTime: expect.any(Number),
+      UserID: '1',
+      GuildID: '2',
+      JoinTime: expect.any(String),
     });
   });
   test('Already exist', async () => {

--- a/tests/implementation/warnings/warnings.test.ts
+++ b/tests/implementation/warnings/warnings.test.ts
@@ -31,11 +31,11 @@ describe('Get Warnings', () => {
     expect(await getUserWarnings(1, 1)).toStrictEqual([
       {
         WarningID: expect.any(String),
-        UserID: 1,
-        GuildID: 1,
+        UserID: '1',
+        GuildID: '1',
         Reason: 'Test Reason',
-        Time: expect.any(Number),
-        AdminID: 2,
+        Time: expect.any(String),
+        AdminID: '2',
       },
     ]);
   });

--- a/tests/implementation/xp/xp.test.ts
+++ b/tests/implementation/xp/xp.test.ts
@@ -21,7 +21,7 @@ describe('Fetching Guild XP data', () => {
   });
   test('Valid Guild ID', async () => {
     await expect(fetchGuildXP(789)).resolves.not.toThrow();
-    expect(await fetchGuildXP(789)).toEqual(expect.arrayContaining([expect.objectContaining({ GuildID: 789, UserID: 123, XP: 7777, Level: 23 }), expect.objectContaining({ GuildID: 789, UserID: 124, XP: 3, Level: 1 })]));
+    expect(await fetchGuildXP(789)).toEqual(expect.arrayContaining([expect.objectContaining({ GuildID: '789', UserID: '123', XP: '7777', Level: '23' }), expect.objectContaining({ GuildID: '789', UserID: '124', XP: '3', Level: '1' })]));
   });
 });
 
@@ -46,7 +46,7 @@ describe('Fetching User XP data', () => {
     await expect(fetchUserXP(790, 124)).rejects.toThrow();
   });
   test('Correct response', async () => {
-    expect(await fetchUserXP(789, 123)).toMatchObject({ GuildID: 789, UserID: 123, XP: 7777, Level: 23 });
+    expect(await fetchUserXP(789, 123)).toMatchObject({ GuildID: '789', UserID: '123', XP: '7777', Level: '23' });
   });
 });
 
@@ -54,7 +54,7 @@ describe('Posting User XP data', () => {
   test('Correct response', async () => {
     await expect(postUserXP(1, 1)).resolves.not.toThrow();
     // expect any number for userGuildID due to auto-increment
-    expect(await fetchUserXP(1, 1)).toMatchObject({ GuildID: 1, UserID: 1, XP: 0, Level: 0 });
+    expect(await fetchUserXP(1, 1)).toMatchObject({ GuildID: '1', UserID: '1', XP: '0', Level: '0' });
     // should fail when trying to add same user in same guild again
     await expect(postUserXP(1, 1)).rejects.toThrow();
   });
@@ -62,7 +62,7 @@ describe('Posting User XP data', () => {
     const time = Math.floor(Date.now() / 1000);
     await expect(postUserXP(1, 1, { XP: 1, Level: 1, XPLock: time, VoiceChannelXPLock: time })).resolves.not.toThrow();
     // expect any number for userGuildID due to auto-increment
-    expect(await fetchUserXP(1, 1)).toMatchObject({ GuildID: 1, UserID: 1, XP: 1, Level: 1, XPLock: time, VoiceChannelXPLock: time });
+    expect(await fetchUserXP(1, 1)).toMatchObject({ GuildID: '1', UserID: '1', XP: '1', Level: '1', XPLock: time.toString(), VoiceChannelXPLock: time.toString() });
   });
 });
 
@@ -80,7 +80,7 @@ describe('Updating User XP data', () => {
     await DB.execute('DELETE FROM Warnings');
   });
   test('Correct response', async () => {
-    const expected = { GuildID: 789, UserID: 124, XP: 333, Level: 11, XPLock: newTime };
+    const expected = { GuildID: '789', UserID: '124', XP: '333', Level: '11', XPLock: newTime.toString() };
     await expect(updateUserXP(789, 124, { XP: 333, Level: 11, XPLock: newTime })).resolves.not.toThrow();
     const result = await fetchUserXP(789, 124);
     expect(result).toEqual(expect.objectContaining(expected));
@@ -113,7 +113,7 @@ describe('Replacing User XP data', () => {
     await DB.execute('DELETE FROM Warnings');
   });
   test('Correct response', async () => {
-    const expected = { GuildID: 789, UserID: 124, XP: 333, Level: 11, XPLock: newTime, VoiceChannelXPLock: newTime };
+    const expected = { GuildID: '789', UserID: '124', XP: '333', Level: '11', XPLock: newTime.toString(), VoiceChannelXPLock: newTime.toString() };
     await expect(replaceUserXP(789, 124, { XP: 333, Level: 11, XPLock: newTime, VoiceChannelXPLock: newTime })).resolves.not.toThrow();
     const result = await fetchUserXP(789, 124);
     expect(result).toEqual(expect.objectContaining(expected));


### PR DESCRIPTION
- Tests, functions and API docs changed to return strings for numbers in functions

This was implemented due to the inaccuracy of BigInts upon the databases return